### PR TITLE
fix: add prompt that password may be required

### DIFF
--- a/observe_configure_mac_script.sh
+++ b/observe_configure_mac_script.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 END_OUTPUT="END_OF_OUTPUT"
+STARTING_PROMPT="This script required sudo privileges, you may be prompted to enter your local user password:"
 
-cd ~ || exit && echo "$SPACER $END_OUTPUT $SPACER"
+cd ~ || exit  && echo "$SPACER $STARTING_PROMPT $SPACER"
 
 config_file_directory="$HOME/observe_config_files"
 


### PR DESCRIPTION
Adds a prompt that notifies users that they may be required to enter a password since the script uses `sudo` to alleviate confusion between your local user password and your ingest token.