### PR TITLE
fix: stop logging ingest token

### DIFF
--- a/observe_configure_mac_script.sh
+++ b/observe_configure_mac_script.sh
@@ -238,7 +238,6 @@ printVariables(){
       log "* VARIABLES *"
       log "$SPACER"
       log "customer_id: $customer_id"
-      log "ingest_token: $ingest_token"
       log "observe_host_name: $observe_host_name"
       log "config_files_clean: $config_files_clean"
       log "datacenter: $datacenter"
@@ -459,7 +458,6 @@ observe_host_name=$(echo "$observe_host_name_base" | sed -e 's|^[^/]*//||' -e 's
 
 log "$SPACER"
 log "customer_id: ${customer_id}"
-log "ingest_token: ${ingest_token}"
 log "observe_host_name_base: ${observe_host_name_base}"
 log "observe_host_name: ${observe_host_name}"
 log "config_files_clean: ${config_files_clean}"
@@ -527,8 +525,6 @@ log
 log "    Hostname:  $DEFAULT_OBSERVE_HOSTNAME"
 log
 log "    Customer ID:  $customer_id"
-log
-log "    Customer Ingest Token:  $ingest_token"
 
 testEject "${testeject}" "EJECT1"
 


### PR DESCRIPTION
Stops logging ingest token. If the log makes it into Observe, that means the token is correct. If the token is incorrect, the validation step will return a 401. Logging the token is bad practice.