### PR TITLE
fix: exclude kernel config for mac

### DIFF
--- a/observe_configure_mac_script.sh
+++ b/observe_configure_mac_script.sh
@@ -662,6 +662,9 @@ if [ "$telegrafinstall" == TRUE ]; then
 
   sudo cp "$sourcefilename" "$filename"
 
+  LC_ALL=C  sed -i '' 's/\[\[inputs\.kernel\]\]/#[[inputs.kernel]]/'  $filename
+     
+
   # ENABLE AND START
   sleep 5
   brew services start telegraf


### PR DESCRIPTION
Excludes the kernel input as it not supported for Mac